### PR TITLE
Fix #4 infinite update trigger

### DIFF
--- a/src/components/growl/growl.vue
+++ b/src/components/growl/growl.vue
@@ -23,7 +23,7 @@
     name: 'vf-growl',
     data: function () {
       return {
-        zIndex: 0,
+        zIndex: ++domHandler.zindex,
 
         container: null,
 
@@ -65,7 +65,6 @@
           return;
         }
 
-        this.zIndex = ++domHandler.zindex;
         domHandler.fadeIn(this.container, 250);
 
         if (!this.sticky) {


### PR DESCRIPTION
Fix #4 issue.

Bug: `zIndex` change has triggered `update()` hook, that has triggered `handleValueChange()` - infinite loop.

Solution: zIndex initialization has moved to `data` object.